### PR TITLE
gha: use runner hooks instead of pre/post scripts for ppc64le runners

### DIFF
--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -34,12 +34,6 @@ jobs:
         stage:
           - ${{ inputs.stage }}
     steps:
-      - name: Prepare the self-hosted runner
-        timeout-minutes: 15
-        run: |
-            "${HOME}/scripts/prepare_runner.sh"
-            sudo rm -rf "$GITHUB_WORKSPACE"/*
-
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
         uses: docker/login-action@v3
@@ -93,12 +87,6 @@ jobs:
         stage:
           - ${{ inputs.stage }}
     steps:
-      - name: Prepare the self-hosted runner
-        timeout-minutes: 15
-        run: |
-            "${HOME}/scripts/prepare_runner.sh"
-            sudo rm -rf "$GITHUB_WORKSPACE"/*
-
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
         uses: docker/login-action@v3
@@ -168,12 +156,6 @@ jobs:
     runs-on: ppc64le
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     steps:
-      - name: Prepare the self-hosted runner
-        timeout-minutes: 15
-        run: |
-            "${HOME}/scripts/prepare_runner.sh"
-            sudo rm -rf "$GITHUB_WORKSPACE"/*
-
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
         uses: docker/login-action@v3

--- a/.github/workflows/publish-kata-deploy-payload.yaml
+++ b/.github/workflows/publish-kata-deploy-payload.yaml
@@ -35,19 +35,6 @@ jobs:
   kata-payload:
     runs-on: ${{ inputs.runner }}
     steps:
-      # TODO - switch ppc64le runner to use `ACTIONS_RUNNER_HOOK_JOB_STARTED`
-      - name: Prepare the self-hosted runner
-        if: ${{ inputs.runner == 'ppc64le' }}
-        timeout-minutes: 15
-        run: |
-          "${HOME}/scripts/prepare_runner.sh"
-          sudo rm -rf "$GITHUB_WORKSPACE"/*
-
-      - name: Adjust a permission for repo
-        if: ${{ inputs.runner == 'ppc64le' }}
-        run: |
-          sudo chown -R "$USER":"$USER" "$GITHUB_WORKSPACE"
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -18,12 +18,6 @@ jobs:
     needs: build-kata-static-tarball-ppc64le
     runs-on: ppc64le
     steps:
-      - name: Prepare the self-hosted runner
-        timeout-minutes: 15
-        run: |
-          bash "${HOME}/scripts/prepare_runner.sh"
-          sudo rm -rf "$GITHUB_WORKSPACE"/*
-
       - name: Login to Kata Containers docker.io
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
+++ b/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
@@ -29,15 +29,6 @@ jobs:
       GOPATH: ${{ github.workspace }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
-      - name: Adjust a permission for repo
-        run: sudo chown -R "$USER":"$USER" "$GITHUB_WORKSPACE"
-
-      - name: Prepare the self-hosted runner
-        timeout-minutes: 15
-        run: |
-          bash "${HOME}/scripts/prepare_runner.sh" cri-containerd
-          sudo rm -rf "$GITHUB_WORKSPACE"/*
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}
@@ -64,6 +55,3 @@ jobs:
 
       - name: Run cri-containerd tests
         run: bash tests/integration/cri-containerd/gha-run.sh run
-
-      - name: Cleanup actions for the self hosted runner
-        run: bash "${HOME}/scripts/cleanup_runner.sh"

--- a/.github/workflows/run-k8s-tests-on-ppc64le.yaml
+++ b/.github/workflows/run-k8s-tests-on-ppc64le.yaml
@@ -43,12 +43,6 @@ jobs:
       USING_NFD: "false"
       TARGET_ARCH: "ppc64le"
     steps:
-      - name: Prepare the self-hosted runner
-        timeout-minutes: 15
-        run: |
-          bash "${HOME}/scripts/prepare_runner.sh" kubernetes
-          sudo rm -rf "$GITHUB_WORKSPACE"/*
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}


### PR DESCRIPTION
This PR makes changes to remove steps to run scripts for preparing and cleaning the runner and instead use runner hooks env variables to manage them.

Fixes: #9934